### PR TITLE
Added node engine in Package.josn 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1"
+      },
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
   },
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/djhemath/snap-nostr.git"


### PR DESCRIPTION
Changes:
Added engines field in package.json to define the required Node.js version.

"engines": {
  "node": ">=18.8.0"
}

This ensures the project will run with Node.js version 18.8.0 or higher.
